### PR TITLE
Fix messaging with bag of holding for less than 1 minute

### DIFF
--- a/World/Source/Scripts/Items/Containers/WeightReductionContainer.cs
+++ b/World/Source/Scripts/Items/Containers/WeightReductionContainer.cs
@@ -192,9 +192,14 @@ namespace Server.Items
             {
                 if (AccessDelayMessage != "")
                     from.SendMessage(Utility.RandomNeutralHue(), AccessDelayMessage);
-
-                from.SendMessage(String.Format("You will need to wait approximately {0} more minutes before you can try again",
-                    NextAccessTime.Subtract(DateTime.Now).Minutes));
+                if(NextAccessTime.Subtract(DateTime.Now).Minutes) < 1){
+                    from.SendMessage(String.Format("You will need to wait approximately {0} more seconds before you can try again",
+                      NextAccessTime.Subtract(DateTime.Now).Seconds));
+                }else {
+                    from.SendMessage(String.Format("You will need to wait approximately {0} more minutes before you can try again",
+                      NextAccessTime.Subtract(DateTime.Now).Minutes));
+                }
+                  
 
                 return false;
             }
@@ -217,8 +222,14 @@ namespace Server.Items
                 if (AccessDelayMessage != "")
                     from.SendMessage(Utility.RandomNeutralHue(), AccessDelayMessage);
 
-                from.SendMessage(String.Format("You will need to wait approximately {0} more minutes before you can try again",
-                    NextAccessTime.Subtract(DateTime.Now).Minutes));
+                if (NextAccessTime.Subtract(DateTime.Now).Minutes) < 1){
+                    from.SendMessage(String.Format("You will need to wait approximately {0} more seconds before you can try again",
+                      NextAccessTime.Subtract(DateTime.Now).Seconds));
+                }else
+                {
+                    from.SendMessage(String.Format("You will need to wait approximately {0} more minutes before you can try again",
+                      NextAccessTime.Subtract(DateTime.Now).Minutes));
+                }
 
                 return false;
             }


### PR DESCRIPTION
Bag of holding message update when less than 1 minute is required to wait. Currently just says 0 minutes for 60 seconds.