### PR TITLE
Allow Bag of Holding loot drops even if player already owns one

### DIFF
--- a/World/Source/Scripts/Items/Containers/Loot.cs
+++ b/World/Source/Scripts/Items/Containers/Loot.cs
@@ -1262,28 +1262,7 @@ namespace Server
 			else
 				i = Construct( m_SArtyTypes );
 				
-			if ( m != null && isBag( i ) )
-			{
-				bool bagged = false;
-
-				if ( m != null && m.Backpack != null )
-				{
-					List<Item> list = new List<Item>();
-					(m.Backpack).RecurseItems( list );
-					foreach ( Item im in list )
-					{
-						if ( isBag( im ) )
-							bagged = true;
-					}
-				}
-
-				if ( bagged )
-				{
-					i.Delete();
-					i = Construct( m_SArtyTypes );
-				}
-			}
-			else if ( Utility.RandomBool() && isBag( i ) )
+			if ( m == null && Utility.RandomBool() && isBag( i ) )
 			{
 				i.Delete();
 				i = Construct( m_SArtyTypes );


### PR DESCRIPTION
Removed the backpack scan in Loot.RandomSArty that rerolled any rolled Bag of Holding (Small/Medium/Large/BagOfHolding) when the player already had one. Players can now stack duplicates. The playerless 50% reroll (rate-limit when m == null) is preserved.