### PR TITLE
Add Double Click talk to Citizens setting

### DIFF
--- a/World/Source/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/World/Source/Scripts/Mobiles/Base/BaseCreature.cs
@@ -7898,7 +7898,27 @@ namespace Server.Mobiles
 				Delete();
 			}
 
+			if ( from is PlayerMobile && ((PlayerMobile)from).Preferences.DoubleClickToTalk && TryTalk( from ) )
+				return;
+
 			base.OnDoubleClick( from );
+		}
+
+		public virtual bool TryTalk( Mobile from )
+		{
+			if ( TalkGumpTitle == null || TalkGumpSubject == null )
+				return false;
+
+			if ( !( from is PlayerMobile ) || !CheckChattingAccess( from ) )
+				return false;
+
+			PlayerMobile mobile = (PlayerMobile)from;
+			if ( mobile.HasGump( typeof( SpeechGump ) ) )
+				return true;
+
+			Server.Misc.IntelligentAction.SayHey( this );
+			mobile.SendGump( new SpeechGump( mobile, TalkGumpTitle, SpeechFunctions.SpeechText( this, mobile, TalkGumpSubject ) ) );
+			return true;
 		}
 
 		private DateTime m_NextPickup;

--- a/World/Source/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/World/Source/Scripts/Mobiles/Base/BaseCreature.cs
@@ -7898,26 +7898,27 @@ namespace Server.Mobiles
 				Delete();
 			}
 
-			if ( from is PlayerMobile && ((PlayerMobile)from).Preferences.DoubleClickToTalk && TryTalk( from ) )
+			PlayerMobile player = from as PlayerMobile;
+			if ( player != null && player.Preferences.DoubleClickToTalk && TryTalk( player ) )
 				return;
 
 			base.OnDoubleClick( from );
 		}
 
-		public virtual bool TryTalk( Mobile from )
+		public virtual bool TryTalk( PlayerMobile from )
 		{
+			if ( from == null )
+				return false;
+
 			if ( TalkGumpTitle == null || TalkGumpSubject == null )
 				return false;
 
-			if ( !( from is PlayerMobile ) || !CheckChattingAccess( from ) )
+			if ( !CheckChattingAccess( from ) )
 				return false;
 
-			PlayerMobile mobile = (PlayerMobile)from;
-			if ( mobile.HasGump( typeof( SpeechGump ) ) )
-				return true;
-
 			Server.Misc.IntelligentAction.SayHey( this );
-			mobile.SendGump( new SpeechGump( mobile, TalkGumpTitle, SpeechFunctions.SpeechText( this, mobile, TalkGumpSubject ) ) );
+			from.CloseGump( typeof( SpeechGump ) );
+			from.SendGump( new SpeechGump( from, TalkGumpTitle, SpeechFunctions.SpeechText( this, from, TalkGumpSubject ) ) );
 			return true;
 		}
 

--- a/World/Source/Scripts/Mobiles/Base/PlayerPreferenceContext.cs
+++ b/World/Source/Scripts/Mobiles/Base/PlayerPreferenceContext.cs
@@ -43,6 +43,8 @@ namespace Server.Mobiles
 			}
 
 			DefaultRunebookSpellType = 2 < version ? (RunebookGump.SpellType)reader.ReadInt() : RunebookGump.SpellType.None;
+
+			DoubleClickToTalk = 3 < version ? reader.ReadBool() : false;
 		}
 
 		[CommandProperty(AccessLevel.GameMaster)]
@@ -77,6 +79,9 @@ namespace Server.Mobiles
 
 		[CommandProperty(AccessLevel.GameMaster)]
 		public bool DoubleClickID { get; set; }
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public bool DoubleClickToTalk { get; set; }
 
 		[CommandProperty(AccessLevel.GameMaster)]
 		public int GumpHue { get; set; }
@@ -119,7 +124,7 @@ namespace Server.Mobiles
 
 		public void Serialize(GenericWriter writer)
 		{
-			writer.Write(3);
+			writer.Write(4);
 
 			writer.Write(DoubleClickID);
 			writer.Write(SuppressVendorTooltip);
@@ -146,6 +151,8 @@ namespace Server.Mobiles
 			writer.Write(RegBar);
 			writer.Write(UsingAncientBook);
 			writer.Write((int)DefaultRunebookSpellType);
+
+			writer.Write(DoubleClickToTalk);
 		}
 	}
 }

--- a/World/Source/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
@@ -1050,11 +1050,11 @@ namespace Server.Mobiles
 			if ( !(this is Humanoid || (this is HouseVisitor && (this.Body == 9 || this.Body == 320))) ){ list.Add( new SpeechGumpEntry( from, this ) ); }
 		}
 
-		public override bool TryTalk( Mobile from )
+		public override bool TryTalk( PlayerMobile from )
 		{
-			if ( this is Humanoid || (this is HouseVisitor && (this.Body == 9 || this.Body == 320)) )
+			if ( from == null )
 				return false;
-			if ( !( from is PlayerMobile ) )
+			if ( this is Humanoid || (this is HouseVisitor && (this.Body == 9 || this.Body == 320)) )
 				return false;
 
 			new SpeechGumpEntry( from, this ).OnClick();

--- a/World/Source/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
@@ -1044,11 +1044,22 @@ namespace Server.Mobiles
 		}
 
 		///////////////////////////////////////////////////////////////////////////
-		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list ) 
-		{ 
-			base.GetContextMenuEntries( from, list ); 
+		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )
+		{
+			base.GetContextMenuEntries( from, list );
 			if ( !(this is Humanoid || (this is HouseVisitor && (this.Body == 9 || this.Body == 320))) ){ list.Add( new SpeechGumpEntry( from, this ) ); }
-		} 
+		}
+
+		public override bool TryTalk( Mobile from )
+		{
+			if ( this is Humanoid || (this is HouseVisitor && (this.Body == 9 || this.Body == 320)) )
+				return false;
+			if ( !( from is PlayerMobile ) )
+				return false;
+
+			new SpeechGumpEntry( from, this ).OnClick();
+			return true;
+		}
 
 		public class SpeechGumpEntry : ContextMenuEntry
 		{

--- a/World/Source/Scripts/Mobiles/Civilized/Merchants/InnKeeper.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Merchants/InnKeeper.cs
@@ -123,9 +123,9 @@ namespace Server.Mobiles
 			list.Add( new SpeechGumpEntry( from, this ) );
 		}
 
-		public override bool TryTalk( Mobile from )
+		public override bool TryTalk( PlayerMobile from )
 		{
-			if ( !( from is PlayerMobile ) )
+			if ( from == null )
 				return false;
 
 			new SpeechGumpEntry( from, this ).OnClick();

--- a/World/Source/Scripts/Mobiles/Civilized/Merchants/InnKeeper.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Merchants/InnKeeper.cs
@@ -117,11 +117,20 @@ namespace Server.Mobiles
 		}
 
 		///////////////////////////////////////////////////////////////////////////
-		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list ) 
-		{ 
-			base.GetContextMenuEntries( from, list ); 
-			list.Add( new SpeechGumpEntry( from, this ) ); 
-		} 
+		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )
+		{
+			base.GetContextMenuEntries( from, list );
+			list.Add( new SpeechGumpEntry( from, this ) );
+		}
+
+		public override bool TryTalk( Mobile from )
+		{
+			if ( !( from is PlayerMobile ) )
+				return false;
+
+			new SpeechGumpEntry( from, this ).OnClick();
+			return true;
+		}
 
 		public class SpeechGumpEntry : ContextMenuEntry
 		{

--- a/World/Source/Scripts/Mobiles/Civilized/Special/Courier.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Special/Courier.cs
@@ -160,12 +160,21 @@ namespace Server.Mobiles
 
 		////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list ) 
-		{ 
-			base.GetContextMenuEntries( from, list ); 
+		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )
+		{
+			base.GetContextMenuEntries( from, list );
 			if ( !from.Blessed )
-				list.Add( new SpeechGumpEntry( from, this ) ); 
-		} 
+				list.Add( new SpeechGumpEntry( from, this ) );
+		}
+
+		public override bool TryTalk( Mobile from )
+		{
+			if ( from.Blessed || !( from is PlayerMobile ) )
+				return false;
+
+			new SpeechGumpEntry( from, this ).OnClick();
+			return true;
+		}
 
 		public class SpeechGumpEntry : ContextMenuEntry
 		{

--- a/World/Source/Scripts/Mobiles/Civilized/Special/Courier.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Special/Courier.cs
@@ -167,9 +167,9 @@ namespace Server.Mobiles
 				list.Add( new SpeechGumpEntry( from, this ) );
 		}
 
-		public override bool TryTalk( Mobile from )
+		public override bool TryTalk( PlayerMobile from )
 		{
-			if ( from.Blessed || !( from is PlayerMobile ) )
+			if ( from == null || from.Blessed )
 				return false;
 
 			new SpeechGumpEntry( from, this ).OnClick();

--- a/World/Source/Scripts/Mobiles/Civilized/Special/EpicCharacter.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Special/EpicCharacter.cs
@@ -91,9 +91,9 @@ namespace Server.Mobiles
 			}
 		}
 
-		public override bool TryTalk( Mobile from )
+		public override bool TryTalk( PlayerMobile from )
 		{
-			if ( from.Blessed || !( from is PlayerMobile ) )
+			if ( from == null )
 				return false;
 
 			new SpeechGumpEntry( from, this ).OnClick();

--- a/World/Source/Scripts/Mobiles/Civilized/Special/EpicCharacter.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Special/EpicCharacter.cs
@@ -81,14 +81,23 @@ namespace Server.Mobiles
 			VirtualArmor = 100;
 		}
 
-		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list ) 
-		{ 
+		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )
+		{
 			base.GetContextMenuEntries( from, list );
 			if ( !from.Blessed )
 			{
 				list.Add( new SpeechGumpEntry( from, this ) );
 				list.Add( new GiftGumpEntry( from, this, true ) );
 			}
+		}
+
+		public override bool TryTalk( Mobile from )
+		{
+			if ( from.Blessed || !( from is PlayerMobile ) )
+				return false;
+
+			new SpeechGumpEntry( from, this ).OnClick();
+			return true;
 		}
 
 		public override bool OnBeforeDeath()

--- a/World/Source/Scripts/Mobiles/Civilized/TownGuards.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/TownGuards.cs
@@ -528,11 +528,20 @@ namespace Server.Mobiles
 			return true;
 		}
 
-		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list ) 
-		{ 
-			base.GetContextMenuEntries( from, list ); 
-			list.Add( new SpeechGumpEntry( from, this ) ); 
-		} 
+		public override void GetContextMenuEntries( Mobile from, List<ContextMenuEntry> list )
+		{
+			base.GetContextMenuEntries( from, list );
+			list.Add( new SpeechGumpEntry( from, this ) );
+		}
+
+		public override bool TryTalk( Mobile from )
+		{
+			if ( !( from is PlayerMobile ) )
+				return false;
+
+			new SpeechGumpEntry( from, this ).OnClick();
+			return true;
+		}
 
 		public class SpeechGumpEntry : ContextMenuEntry
 		{

--- a/World/Source/Scripts/Mobiles/Civilized/TownGuards.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/TownGuards.cs
@@ -534,9 +534,9 @@ namespace Server.Mobiles
 			list.Add( new SpeechGumpEntry( from, this ) );
 		}
 
-		public override bool TryTalk( Mobile from )
+		public override bool TryTalk( PlayerMobile from )
 		{
-			if ( !( from is PlayerMobile ) )
+			if ( from == null )
 				return false;
 
 			new SpeechGumpEntry( from, this ).OnClick();

--- a/World/Source/Scripts/System/Help/HelpGump.cs
+++ b/World/Source/Scripts/System/Help/HelpGump.cs
@@ -634,7 +634,7 @@ namespace Server.Engines.Help
 				AddSetting(xs, g, from, "Double Click to ID Items", PageActionType.Setting_DoubleClickToIDItems, PageActionType.Setting_DoubleClickToIDItems_Info);
 				if ( xr == 1 ){ g += j; xr=0; xs=xm; } else { xr=1; xs=xo; }
 
-				AddSetting(xs, g, from, "Double Click talk to Citizens", PageActionType.Setting_DoubleClickToTalk, PageActionType.Setting_DoubleClickToTalk_Info);
+				AddSetting(xs, g, from, "Double Click Talk", PageActionType.Setting_DoubleClickToTalk, PageActionType.Setting_DoubleClickToTalk_Info);
 				if ( xr == 1 ){ g += j; xr=0; xs=xm; } else { xr=1; xs=xo; }
 
 				AddSetting(xs, g, from, "Single ID Attempt", PageActionType.Setting_SingleAttemptID, PageActionType.Setting_SingleAttemptID_Info);
@@ -2279,7 +2279,7 @@ namespace Server.Engines.Help
 				case PageActionType.Setting_DoubleClickToTalk_Info:
 				{
 					scrollbar = false;
-					title = "Double Click talk to Citizens";
+					title = "Double Click Talk";
 					info = "When enabled, double clicking a citizen or other talkative NPC (the ones with a 'Talk' option in their context menu - found at meeting spots, town guards, innkeepers, couriers, and epic characters) will open their conversation directly instead of opening their paperdoll. NPCs without anything to say still show their paperdoll as normal.";
 					break;
 				}

--- a/World/Source/Scripts/System/Help/HelpGump.cs
+++ b/World/Source/Scripts/System/Help/HelpGump.cs
@@ -230,6 +230,8 @@ namespace Server.Engines.Help
 			Setting_SingleAttemptID_Info,
 			Setting_ColorlessFabricBreakdown,
 			Setting_ColorlessFabricBreakdown_Info,
+			Setting_DoubleClickToTalk,
+			Setting_DoubleClickToTalk_Info,
 		}
 
 		public static void Initialize()
@@ -632,6 +634,9 @@ namespace Server.Engines.Help
 				AddSetting(xs, g, from, "Double Click to ID Items", PageActionType.Setting_DoubleClickToIDItems, PageActionType.Setting_DoubleClickToIDItems_Info);
 				if ( xr == 1 ){ g += j; xr=0; xs=xm; } else { xr=1; xs=xo; }
 
+				AddSetting(xs, g, from, "Double Click talk to Citizens", PageActionType.Setting_DoubleClickToTalk, PageActionType.Setting_DoubleClickToTalk_Info);
+				if ( xr == 1 ){ g += j; xr=0; xs=xm; } else { xr=1; xs=xo; }
+
 				AddSetting(xs, g, from, "Single ID Attempt", PageActionType.Setting_SingleAttemptID, PageActionType.Setting_SingleAttemptID_Info);
 				if ( xr == 1 ){ g += j; xr=0; xs=xm; } else { xr=1; xs=xo; }
 
@@ -892,6 +897,7 @@ namespace Server.Engines.Help
 				case PageActionType.Setting_WeaponAbilityNames: return from.Preferences.CharacterWepAbNames;
 				case PageActionType.Setting_UseAncientSpellbook: return ResearchSettings.BookCaster( from );
 				case PageActionType.Setting_DoubleClickToIDItems: return from.Preferences.DoubleClickID;
+				case PageActionType.Setting_DoubleClickToTalk: return from.Preferences.DoubleClickToTalk;
 				case PageActionType.Setting_OrdinaryResources: return from.HarvestOrdinary;
 				case PageActionType.Setting_RemoveVendorGoldSafeguard: return from.Preferences.IgnoreVendorGoldSafeguard;
 				case PageActionType.Setting_SuppressVendorTooltips: return from.Preferences.SuppressVendorTooltip;
@@ -1383,6 +1389,12 @@ namespace Server.Engines.Help
 					case PageActionType.Setting_DoubleClickToIDItems:
 					{
 						from.Preferences.DoubleClickID = !from.Preferences.DoubleClickID;
+						from.SendGump( new Server.Engines.Help.HelpGump( from, 12 ) );
+						break;
+					}
+					case PageActionType.Setting_DoubleClickToTalk:
+					{
+						from.Preferences.DoubleClickToTalk = !from.Preferences.DoubleClickToTalk;
 						from.SendGump( new Server.Engines.Help.HelpGump( from, 12 ) );
 						break;
 					}
@@ -2261,6 +2273,14 @@ namespace Server.Engines.Help
 					scrollbar = false;
 					title = "Double Click to ID Items";
 					info = "Enabling this will allow your character to try and identify items by double clicking them.<BR><BR>NOTE: if you are using any third party software, that tries to open all of your containers, then that third party software will try to identify these items without your consent.";
+					break;
+				}
+
+				case PageActionType.Setting_DoubleClickToTalk_Info:
+				{
+					scrollbar = false;
+					title = "Double Click talk to Citizens";
+					info = "When enabled, double clicking a citizen or other talkative NPC (the ones with a 'Talk' option in their context menu - found at meeting spots, town guards, innkeepers, couriers, and epic characters) will open their conversation directly instead of opening their paperdoll. NPCs without anything to say still show their paperdoll as normal.";
 					break;
 				}
 


### PR DESCRIPTION
Adds a new player preference that opens an NPC's conversation on double click instead of their paperdoll. Applies to NPCs with a 'Talk' context menu option: citizens at meeting spots, town guards, innkeepers, couriers, and epic characters.

Introduces BaseCreature.TryTalk() as a virtual override point so subclasses with custom SpeechGumpEntry implementations route through the same path used by the context menu.