### PR TITLE
Mannequin: block non-owners from opening or snooping the backpack

### DIFF
--- a/World/Source/Scripts/Mobiles/Base/Mannequin.cs
+++ b/World/Source/Scripts/Mobiles/Base/Mannequin.cs
@@ -731,7 +731,18 @@ namespace Server.Mobiles
 
 		public override bool IsAccessibleTo( Mobile m )
 		{
-			return true;
+			// Gate on ownership. This is the check Mobile.Use runs before BOTH the
+			// snoop branch and the normal "open container" branch, so returning false
+			// for non-owners blocks them from opening OR snooping the pack entirely
+			// (they get the "not accessible" message). CanManage already grants GMs
+			// and house co-owners. Owners open via Mannequin.OpenBackpack, which calls
+			// DisplayTo directly and doesn't depend on this.
+			Mannequin man = RootParent as Mannequin;
+
+			if ( man != null && man.CanManage( m ) )
+				return base.IsAccessibleTo( m );
+
+			return false;
 		}
 
 		public override bool CheckItemUse( Mobile from, Item item )


### PR DESCRIPTION
MannequinBackpack.IsAccessibleTo returned true unconditionally, which is the gate Mobile.Use checks before both the snoop branch and the normal open branch. Combined with IsSnoop returning false, any non-owner could open the pack freely. Gate IsAccessibleTo on CanManage so only the owner (or GMs/co-owners) can open or snoop it; everyone else gets the "not accessible" message. This also covers the spell snoop vectors (Telekinesis/Psychokinesis/ForceGrip), which all check IsAccessibleTo first.