### PR TITLE
Enforce range/LOS on double-click-to-talk to match context menu

### DIFF
--- a/World/Source/Scripts/Mobiles/Base/BaseCreature.cs
+++ b/World/Source/Scripts/Mobiles/Base/BaseCreature.cs
@@ -7916,6 +7916,9 @@ namespace Server.Mobiles
 			if ( !CheckChattingAccess( from ) )
 				return false;
 
+			if ( !from.InRange( this, 12 ) )
+				return false;
+
 			Server.Misc.IntelligentAction.SayHey( this );
 			from.CloseGump( typeof( SpeechGump ) );
 			from.SendGump( new SpeechGump( from, TalkGumpTitle, SpeechFunctions.SpeechText( this, from, TalkGumpSubject ) ) );

--- a/World/Source/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Citizens/Citizens.cs
@@ -1057,7 +1057,12 @@ namespace Server.Mobiles
 			if ( this is Humanoid || (this is HouseVisitor && (this.Body == 9 || this.Body == 320)) )
 				return false;
 
-			new SpeechGumpEntry( from, this ).OnClick();
+			SpeechGumpEntry entry = new SpeechGumpEntry( from, this );
+
+			if ( !from.CanSee( this ) || !from.InRange( this, entry.Range ) )
+				return false;
+
+			entry.OnClick();
 			return true;
 		}
 

--- a/World/Source/Scripts/Mobiles/Civilized/Merchants/InnKeeper.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Merchants/InnKeeper.cs
@@ -128,7 +128,12 @@ namespace Server.Mobiles
 			if ( from == null )
 				return false;
 
-			new SpeechGumpEntry( from, this ).OnClick();
+			SpeechGumpEntry entry = new SpeechGumpEntry( from, this );
+
+			if ( !from.CanSee( this ) || !from.InRange( this, entry.Range ) )
+				return false;
+
+			entry.OnClick();
 			return true;
 		}
 

--- a/World/Source/Scripts/Mobiles/Civilized/Special/Courier.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Special/Courier.cs
@@ -172,7 +172,12 @@ namespace Server.Mobiles
 			if ( from == null || from.Blessed )
 				return false;
 
-			new SpeechGumpEntry( from, this ).OnClick();
+			SpeechGumpEntry entry = new SpeechGumpEntry( from, this );
+
+			if ( !from.CanSee( this ) || !from.InRange( this, entry.Range ) )
+				return false;
+
+			entry.OnClick();
 			return true;
 		}
 

--- a/World/Source/Scripts/Mobiles/Civilized/Special/EpicCharacter.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/Special/EpicCharacter.cs
@@ -96,7 +96,12 @@ namespace Server.Mobiles
 			if ( from == null )
 				return false;
 
-			new SpeechGumpEntry( from, this ).OnClick();
+			SpeechGumpEntry entry = new SpeechGumpEntry( from, this );
+
+			if ( !from.CanSee( this ) || !from.InRange( this, entry.Range ) )
+				return false;
+
+			entry.OnClick();
 			return true;
 		}
 

--- a/World/Source/Scripts/Mobiles/Civilized/TownGuards.cs
+++ b/World/Source/Scripts/Mobiles/Civilized/TownGuards.cs
@@ -539,7 +539,12 @@ namespace Server.Mobiles
 			if ( from == null )
 				return false;
 
-			new SpeechGumpEntry( from, this ).OnClick();
+			SpeechGumpEntry entry = new SpeechGumpEntry( from, this );
+
+			if ( !from.CanSee( this ) || !from.InRange( this, entry.Range ) )
+				return false;
+
+			entry.OnClick();
 			return true;
 		}
 


### PR DESCRIPTION
The TryTalk overrides on Citizens, InnKeeper, Courier, EpicCharacter, and TownGuards invoked SpeechGumpEntry.OnClick() directly, bypassing the CanSee/InRange checks the context-menu packet handler enforces. Gate each override on from.CanSee(this) and the entry Range so double-click talk obeys the same rules as the Talk context menu. Also enforce the TalkGumpEntry range (12) in the base BaseCreature.TryTalk.