### PR TITLE
Fix keyless players recalling out of Kuldar bottle world

### DIFF
--- a/World/Source/Scripts/System/Regions/Core/World.cs
+++ b/World/Source/Scripts/System/Regions/Core/World.cs
@@ -628,7 +628,7 @@ namespace Server.Misc
 			Land land = Server.Lands.GetLand( map, location, x, y );
 			Region reg = Region.Find( location, map );
 
-			if ( land == Land.Kuldar && PlayerSettings.GetDiscovered( m, "the Bottle World of Kuldar" ) && !PlayerSettings.GetKeys( m, "VordoKey" ) )
+			if ( land == Land.Kuldar && !PlayerSettings.GetKeys( m, "VordoKey" ) )
 				canLeave = false;
 
 			if ( land == Land.SkaraBrae )


### PR DESCRIPTION
The Vordo recall change removed the unconditional Land.Kuldar block from RegionAllowedRecall, assuming AllowEscape already covered it. But AllowEscape only blocked Kuldar when GetDiscovered was true, while the removed guard blocked everyone. Keyless players whose discovery flag was never set (logged in inside, moved/resurrected in, etc.) passed every check and recalled out freely.

Drop the discovery requirement from the AllowEscape Kuldar guard so it matches the moongate rule: in Kuldar without VordoKey -> cannot leave.