### PR TITLE
Add one-tap fee payment button when opening a new shoppe

### DIFF
--- a/World/Source/Scripts/Engines and Systems/Trades/Global Shoppe/Core/ShoppeBase.cs
+++ b/World/Source/Scripts/Engines and Systems/Trades/Global Shoppe/Core/ShoppeBase.cs
@@ -4,6 +4,7 @@ using Server.Items;
 using Server.Misc;
 using Server.Mobiles;
 using Server.Utilities;
+using System;
 using System.Collections.Generic;
 
 namespace Server.Engines.GlobalShoppe
@@ -60,6 +61,48 @@ namespace Server.Engines.GlobalShoppe
 		public bool HasGoldCapacity(TradeSkillContext context, CustomerContext customer)
 		{
 			return context.Gold + customer.GoldReward <= ShoppeConstants.MAX_GOLD;
+		}
+
+		public bool NeedsFeePayment(Mobile from, TradeSkillContext context)
+		{
+			return !context.FeePaid && ShoppeConstants.MIN_SKILL <= from.Skills[PrimarySkill].Value;
+		}
+
+		public bool TryPayFee(Mobile from, TradeSkillContext context)
+		{
+			if (context.FeePaid)
+				return true;
+
+			int fee = ShoppeConstants.SHOPPE_FEE;
+
+			Container pack = from.Backpack;
+			int packGold = pack == null ? 0 : pack.GetAmount(typeof(Gold));
+			int bankGold = Banker.GetBalance(from);
+
+			if (packGold + bankGold < fee)
+			{
+				from.SendMessage(0x22, "You need {0} gold in your backpack or bank to open this shoppe.", fee);
+				return false;
+			}
+
+			int fromPack = Math.Min(packGold, fee);
+			int fromBank = fee - fromPack;
+
+			if (fromPack > 0)
+				pack.ConsumeUpTo(typeof(Gold), fromPack);
+
+			if (fromBank > 0)
+				Banker.Withdraw(from, fromBank);
+
+			context.FeePaid = true;
+
+			string source =
+				fromBank == 0 ? "your backpack" :
+				fromPack == 0 ? "your bank" :
+				"your backpack and bank";
+			from.SendMessage("You paid {0} gold from {1} to open this shoppe.", fee, source);
+
+			return true;
 		}
 
 		public override void OnDoubleClick(Mobile from)

--- a/World/Source/Scripts/Engines and Systems/Trades/Global Shoppe/Gumps/ShoppeGump.cs
+++ b/World/Source/Scripts/Engines and Systems/Trades/Global Shoppe/Gumps/ShoppeGump.cs
@@ -11,6 +11,7 @@ namespace Server.Engines.GlobalShoppe
 			Close = 0,
 			Help = 1,
 			ShowRewards = 2,
+			PayFee = 3,
 			AcceptBase = 50,
 			RejectBase = 100,
 			DoOrderBase = 150,
@@ -159,6 +160,17 @@ namespace Server.Engines.GlobalShoppe
 				if (!string.IsNullOrWhiteSpace(requirements))
 				{
 					AddTextCard(y, requirements);
+
+					if (shoppe.NeedsFeePayment(from, context))
+					{
+						int by = y + CARD_HEIGHT + 20;
+						int bx = 20 + (CARD_WIDTH / 2) - 140;
+
+						AddButton(bx, by, 4005, 4007, (int)Actions.PayFee, GumpButtonType.Reply, 0);
+						TextDefinition.AddHtmlText(this, bx + 38, by + 2, 320, 20,
+							string.Format("Pay {0} gold from backpack/bank", ShoppeConstants.SHOPPE_FEE), HtmlColors.MUSTARD);
+					}
+
 					return;
 				}
 
@@ -264,6 +276,10 @@ namespace Server.Engines.GlobalShoppe
 						));
 					}));
 					return;
+				}
+				else if (buttonID == (int)Actions.PayFee)
+				{
+					m_Shoppe.TryPayFee(player, m_Context);
 				}
 			}
 


### PR DESCRIPTION
Adds a button on the shoppe requirements screen to auto-pay the shoppe fee, pulling gold from the player's backpack first and covering any shortfall from the bank, instead of requiring gold to be dragged onto the shoppe.