### PR TITLE
Fix Journal on Familiars not registering in the player library

### DIFF
--- a/World/Source/Scripts/System/Commands/Player/MyLibrary.cs
+++ b/World/Source/Scripts/System/Commands/Player/MyLibrary.cs
@@ -285,7 +285,7 @@ namespace Server.Gumps
 			else if ( book.Name == "Hidden Traps" ){ num = 37; }
 			else if ( book.Name == "The Ice Queen" ){ num = 38; }
 			else if ( book.Name == "The Jedi Order" ){ num = 39; }
-			else if ( book.Name == "Journal on Familiars" ){ num = 40; }
+			else if ( book is FamiliarClue ){ num = 40; }
 			else if ( book.Name == "The Knight Who Fell" ){ num = 41; }
 			else if ( book.Name == "Leather & Bone Crafts" ){ num = 42; }
 			else if ( book.Name == "Legend of the Sky Castle" ){ num = 43; }


### PR DESCRIPTION
MyLibrary.readBook matched this book by display name ("Journal on Familiars"), but FamiliarClue's constructor sets BookTitle/Name to just "Journal", so the branch could never fire and reading the book never recorded it.

Match on the type instead, following the existing `book is LodorBook` pattern already used in the same chain. BookTitle and Name are serialized, so the copy already placed in the world save keeps the name "Journal" -- a constructor change alone would not have fixed the book players can actually find at Sosaria (5910, 2230) in Dungeon Clues.